### PR TITLE
BACKEND: added a new schedule_view method that retrieves all UF games for current year | added url for frontend to call

### DIFF
--- a/HealthyGatorSportsFanDjango/app/views.py
+++ b/HealthyGatorSportsFanDjango/app/views.py
@@ -406,3 +406,25 @@ def home_tile_view(request):
         message = response["message"]
     
     return JsonResponse(response)
+
+
+@csrf_exempt
+def schedule_view(request):
+    configuration = cfbd.Configuration(
+        host="https://apinext.collegefootballdata.com",
+        access_token=os.getenv('COLLEGE_FOOTBALL_API_KEY')
+    )
+    apiInstance = cfbd.GamesApi(cfbd.ApiClient(configuration))
+    current_year = date.today().year
+    try:
+        games = apiInstance.get_games(year=current_year, team='Florida', conference='SEC')
+        games_list = [game.to_dict() for game in games]
+        return JsonResponse({"data": games_list})
+    except Exception as e:
+        print(e)
+        return JsonResponse(
+            {"error": f"Could not retrieve UF games for {current_year}"},
+            status=500
+        )
+    
+    

--- a/HealthyGatorSportsFanDjango/project/urls.py
+++ b/HealthyGatorSportsFanDjango/project/urls.py
@@ -20,7 +20,7 @@ from django.urls import path
 #from HealthyGatorSportsFanDjango.app.views import index, CreateUserView, poll_cfbd_view, CreateUserDataView, NotificationListView, CreateNotificationView, DeleteNotificationView, BulkDeleteNotificationsView, UserLoginView, LatestUserDataView, UserUpdateView, CheckEmailView
 # for running locally
 #from app.views import index, CreateUserView, poll_cfbd_view, BasicInfoView, GoalCollectionView, CreateUserDataView (before merge)
-from app.views import index, CreateUserView, poll_cfbd_view, home_tile_view, CreateUserDataView, NotificationListView, CreateNotificationView, DeleteNotificationView, BulkDeleteNotificationsView, UserLoginView, LatestUserDataView, UserUpdateView, CheckEmailView
+from app.views import index, CreateUserView, poll_cfbd_view, home_tile_view, schedule_view, CreateUserDataView, NotificationListView, CreateNotificationView, DeleteNotificationView, BulkDeleteNotificationsView, UserLoginView, LatestUserDataView, UserUpdateView, CheckEmailView
 
 # Import drf-yasg components
 from drf_yasg.views import get_schema_view 
@@ -57,6 +57,7 @@ urlpatterns = [
     path('notificationdata/deleteall/<int:user_id>/', BulkDeleteNotificationsView.as_view(), name='notifications-delete-all'),
     path('poll-cfbd/', poll_cfbd_view, name='poll_cfbd'),
     path('home-tile/', home_tile_view, name='home_tile_view'),
+    path('schedule-tile/', schedule_view, name='schedule_tile'),
     
     # API endpoint for Swagger
     path('swagger/', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),


### PR DESCRIPTION
## HealthyGatorSportsFanDjango/app/views.py
- added new method that will get the current year's games for UF and return them as a JSON
-  if all went well, JSON contains data attribute with the API response
-  if error, JSON contains error attribute and the error is logged

## HealthyGatorSportsFanDjango/projects/urls.py
- created a new API url for the frontend to call to be able to get the 2025 football games from method defined above